### PR TITLE
Fix build and update to v2

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+    "sdk": {
+        "version": "6.0.300",
+        "rollForward": "latestFeature"
+    }
+}

--- a/src/App/App.fs
+++ b/src/App/App.fs
@@ -1,8 +1,7 @@
 module App
 
 open Sutil
-open Sutil.DOM
-open Sutil.Attr
+open Sutil.CoreElements
 
 type Model = { Counter : int }
 

--- a/src/App/App.fsproj
+++ b/src/App/App.fsproj
@@ -14,7 +14,7 @@
     </When>
     <When Condition=" '$(UseLocalSutil)'=='False' ">
         <ItemGroup>
-            <PackageReference Include="Sutil" Version="1.0.0-*" />
+            <PackageReference Include="Sutil" Version="2.0.0-*" />
         </ItemGroup>
     </When>
   </Choose>


### PR DESCRIPTION
These are pretty much the minimal changes I needed to do to make the template work on my system with sdk7 installed. Another option would be to use a Fable 4 prerelease instead of pinning dotnet to v6. What do you prefer?